### PR TITLE
feature: 플레이어 좌표값, 현재 방향키 소켓으로 전송

### DIFF
--- a/utils/gameRooms.js
+++ b/utils/gameRooms.js
@@ -43,6 +43,17 @@ exports.getPlayersInfo = roomId => {
   return playersInfo;
 };
 
+exports.updatePlayerPosition = (playerId, currentDirection, coordinateX, coordinateY) => {
+  players[playerId] = {
+    ...players[playerId],
+    currentDirection,
+    coordinateX,
+    coordinateY,
+  };
+
+  return players[playerId];
+};
+
 exports.getAllRooms = () => {
   return rooms;
 };


### PR DESCRIPTION
## 작업사항

1. 클라이언트에서 캐릭터 이동 또는 멈춤 시 해당 플레이어 정보 받은 후 해당 방에 참여한 플레이어에게 socket으로 전송

## 체크리스트

- [ ] 불필요한 로직은 없는지
- [ ] socket 이벤트명 적절한지

## 관련이슈

- 플레이어의 정보를 socket.broadcast.to(roomId) 로 자신 외의 플레이어에게 전송하고 싶었지만 호스트의 경우 소켓아이디와 roomId가 일치한다는 문제점이 있었습니다. 따라서 io.to(roomId) 로 바꾸어서 로직을 작성하고 클라이언트 부분에서 자신의 정보가 넘어왔을 때에 대한 처리를 하게되었습니다.
- 게임 입장 시 처음에 플레이어가 정면을 바라보기 때문에 player의 속성에 currentDirection의 default 값으로 stop을 주었습니다. (클라이언트 부분에서 멈추었을 때 정면처리)
- 모든 플레이어의 화면에서 모든 플레이어들의 위치가 같아야 하기 때문에 캐릭터 생성 시 플레이어의 coordinateX와 coordinateY의 속성에 랜덤값을 추가하였습니다. 